### PR TITLE
New protagonist needs C++11

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,16 +1,16 @@
+sudo: required
+dist: trusty
 language: python
 before_install:
   - node --version
   - npm install --python=python2 -g dredd
   - bundle install
-
 python:
   - "2.7"
   - "3.2"
   - "3.3"
   - "3.4"
   - "3.5"
-
 script:
   - python -B -m unittest discover
   - pip install -e .


### PR DESCRIPTION
To be able to install newer Dredd, one will need a C++ compiler able to compile C++11. In the future we will eventually migrate to js-only parser by default and no compiler will be needed, but as of now, this change is needed in order to make Dredd work with Travis CI.

https://github.com/apiaryio/protagonist/blob/master/CHANGELOG.md#breaking