### PR TITLE
Hook files must be sorted by file names.

### DIFF
--- a/dredd_hooks/dredd.py
+++ b/dredd_hooks/dredd.py
@@ -118,11 +118,12 @@ def add_named_hook(obj, hook, name):
 
 def load_hook_files(pathname):
     """
-     Loads files either defined as a glob or a single file path.
+     Loads files either defined as a glob or a single file path
+     sorted by filenames.
     """
     global hooks
 
-    fsglob = glob.iglob(pathname)
+    fsglob = sorted(glob.iglob(pathname))
     for path in fsglob:
         real_path = os.path.realpath(path)
         # Append hooks file directory to the sys.path so submodules can be


### PR DESCRIPTION
## Example
We have some hook files, they named for control hooks flow in case of using glob filepathes:
```
10-first.py
20-second.py
30-third.py
```

dredd.yml using glob path:
```
hookfiles:
        - /var/_hooks/*.py
```

At the Dredd start it will produce console output:
`info: Found Hookfiles: 0=/_hooks/10-first.py, 1=/_hooks/20-second.py, 2=/_hooks/30-third.py`
so we'll expect this order of hooks execution.

But python glob returns unordered files list. As a result hook files are executed unordered  and we can't control hooks execution flow.

