### PR TITLE
Use newer node version

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,9 @@
 sudo: false
 language: python
 before_install:
+- nvm install node && nvm use node
 - node --version
-- npm install --python=python2 -g dredd
+- npm install --python=python2 -g dredd --no-optional
 - bundle install
 python:
 - '2.7'


### PR DESCRIPTION
Soon Dredd won't support node versions 0.10 and 0.12: https://github.com/apiaryio/dredd/pull/716 Those are ancient and officially dead now (not supported by node maintainers anymore). Node setup for Travis CI builds of different languages (Ruby, Python, Perl, PHP, ...) is outdated and uses these dead versions by default. This PR ensures the build will install Dredd with correct node version. The `node` alias in the `nvm install node` command points to the latest node version.

The `--no-optional` flag in Dredd installation command [skips C++11 compilation](http://dredd.readthedocs.io/en/latest/installation/#compiled-vs-pure-javascript) (speeds up the build).