### PR TITLE
Do not specify Python version in Travis CI config

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,7 @@ language: python
 before_install:
 - nvm install node && nvm use node
 - node --version
-- npm install --python=python2 -g dredd --no-optional
+- npm install -g dredd --no-optional
 - bundle install
 python:
 - '2.7'


### PR DESCRIPTION
The Python version was specified to ensure node-gyp compilation works (it supports Python 2 only). We use --no-optional now to speed up the installation on CI, which means no compilation should take place at all. In that case, specifying the Python version is redundant.

Based on @kylef's comment under #30.