### PR TITLE
Log full tracebacks, also for hooks

### DIFF
--- a/dredd_hooks/dredd.py
+++ b/dredd_hooks/dredd.py
@@ -9,6 +9,7 @@ import sys
 import os
 import glob
 import imp
+import traceback
 from functools import wraps
 
 try:
@@ -109,6 +110,10 @@ class HookHandler(SocketServer.StreamRequestHandler):
                     self.wfile.write(msg)
         except ValueError:
             print("\nConnection closed\n", file=sys.stderr)
+        except Exception as e:
+            traceback.print_exc(file=sys.stderr)
+            sys.stderr.flush()
+            raise
 
 
 def add_named_hook(obj, hook, name):
@@ -246,6 +251,6 @@ def main(args):
     except KeyboardInterrupt:
         shutdown()
     except Exception as e:
-        print(e, file=sys.stderr)
+        traceback.print_exc(file=sys.stderr)
         sys.stderr.flush()
         raise


### PR DESCRIPTION
This helped me solve #32.

What was happening was that my hook was throwing an exception, but as the handler wasn't catching that and writing it to `stderr`, it was being swallowed by `SocketServer`. This breaks the `while True:` loop, and then Dredd times out.

I figured this out in the end by putting a ton of write-to-file logs everywhere.