### PR TITLE
Print more startup information

### DIFF
--- a/dredd_hooks/dredd.py
+++ b/dredd_hooks/dredd.py
@@ -134,6 +134,9 @@ def load_hook_files(pathname):
         fsglob = sorted(glob.iglob(pathname))
 
     for path in fsglob:
+        print('Found hook', path)
+        sys.stdout.flush()
+
         real_path = os.path.realpath(path)
         # Append hooks file directory to the sys.path so submodules can be
         # loaded too.
@@ -241,6 +244,12 @@ def main(files, host=HOST, port=PORT):
     global server
     global hooks
     hooks = Hooks()
+    print('Starting Dredd Python Hooks with:')
+    print('  - Files:', files)
+    print('  - Host:', host)
+    print('  - Port:', port)
+    sys.stdout.flush()
+
     # Load hook files
     for f in files:
         load_hook_files(f)


### PR DESCRIPTION
I'm not sure how you feel about reporting from hook libraries, so feel free to turn this one down. Just added it since this helped me a _lot_ with debugging the last few issues.

It might be useful instead to use [`logging`](https://docs.python.org/3.6/library/logging.html#module-logging) and accept an additional `--level` argument from Dredd, to keep the same (or a similar) log level across Dredd and its hooks?