### PR TITLE
Use entry point for dredd-hooks-python instead of bin

### DIFF
--- a/dredd_hooks/__init__.py
+++ b/dredd_hooks/__init__.py
@@ -4,10 +4,10 @@
 #  Copyright (c) 2015, 2016 Apiary Czech Republic, s.r.o.
 #  License: MIT
 #
-
-from .dredd import (before_all, after_all, before_each, before_each_validation,
-                    after_each, before_validation, before, after,
-                    main, shutdown, HOST, PORT, MESSAGE_DELIMITER)
+from .dredd import (HOST, MESSAGE_DELIMITER, PORT, after, after_all,
+                    after_each, before, before_all, before_each,
+                    before_each_validation, before_validation,
+                    main, shutdown)
 
 
 __all__ = ['before_all',
@@ -24,4 +24,4 @@ __all__ = ['before_all',
            'PORT',
            'MESSAGE_DELIMITER']
 
-__version__ = '0.1.0'
+__version__ = '0.1.3'

--- a/dredd_hooks/__main__.py
+++ b/dredd_hooks/__main__.py
@@ -1,0 +1,15 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+#
+#  Copyright (c) 2015, 2016 Apiary Czech Republic, s.r.o.
+#  License: MIT
+#
+
+
+def main():
+    from dredd_hooks import cli
+    cli.main()
+
+
+if __name__ == '__main__':
+    main()

--- a/dredd_hooks/cli.py
+++ b/dredd_hooks/cli.py
@@ -5,10 +5,13 @@
 #  License: MIT
 #
 from __future__ import print_function
+
+import sys
+
 import dredd_hooks as dredd
 
 
-if __name__ == '__main__':
+def run_dredd_hooks():
     import argparse
     parser = argparse.ArgumentParser(
         description='Start the Python Dredd hooks worker.'
@@ -23,3 +26,11 @@ if __name__ == '__main__':
 
     args = parser.parse_args()
     dredd.main(args.files, host=args.host, port=args.port)
+
+
+def main():
+    """Run dredd_hooks as a script."""
+    try:
+        sys.exit(run_dredd_hooks())
+    except KeyboardInterrupt:
+        pass

--- a/dredd_hooks/dredd.py
+++ b/dredd_hooks/dredd.py
@@ -4,11 +4,12 @@
 #  License: MIT
 #
 from __future__ import print_function
-import json
-import sys
-import os
+
 import glob
 import imp
+import json
+import os
+import sys
 import traceback
 from functools import wraps
 
@@ -123,8 +124,8 @@ def add_named_hook(obj, hook, name):
 
 def load_hook_files(pathname):
     """
-     Loads files either defined as a glob or a single file path
-     sorted by filenames.
+    Loads files either defined as a glob or a single file path
+    sorted by filenames.
     """
     global hooks
 
@@ -175,6 +176,7 @@ def flusher(func):
         return result
     flusher.flushed[func] = call
     return call
+
 
 flusher.flushed = {}
 

--- a/setup.py
+++ b/setup.py
@@ -1,11 +1,11 @@
 # -*- coding: utf-8 -*-
 
-from setuptools import setup, find_packages
+from setuptools import find_packages, setup
 
 long_desc = open('README.rst').read()
 
 setup(
-    name='dredd_hooks',
+    name='dredd-hooks-python',
     version='0.1.3',
     url='https://github.com/apiaryio/dredd-hooks-python/',
     download_url='http://pypi.python.org/pypi/dredd_hooks',
@@ -31,9 +31,13 @@ setup(
     ],
     keywords='HTTP API testing Dredd',
     platforms='any',
-    scripts=['bin/dredd-hooks-python'],
     packages=find_packages(),
     include_package_data=True,
+    entry_points={
+        'console_scripts': [
+            'dredd-hooks-python = dredd_hooks.__main__:main'
+        ],
+    },
     tests_require=['flake8'],
-    test_suite="test",
+    test_suite='test',
 )


### PR DESCRIPTION
This fixes using dredd-hooks-python with Windows, which is currently not working (at least for me).
Installing with pip or even from source doesn't compile the necessary executables that are required to run it from command line, resulting in the following error message:
```
> dredd-hooks-python
'dredd-hooks-python' is not recognized as an internal or external command,
operable program or batch file.
```
Also included some minor clean-ups.
